### PR TITLE
Import unicode_literals from __futures__ for unicode handling in 2.7

### DIFF
--- a/inflect.py
+++ b/inflect.py
@@ -61,6 +61,8 @@ Exceptions:
 
 '''
 
+from __future__ import unicode_literals
+
 from re import match, search, subn, IGNORECASE, VERBOSE
 from re import split as splitre
 from re import error as reerror

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -8,9 +8,11 @@ import inflect
 
 
 class TestUnicode(unittest.TestCase):
-    def test_unicode(self):
+    """ Unicode compatibility test cases """
+
+    def test_unicode_plural(self):
+        """ Unicode compatibility test cases for plural """
         engine = inflect.engine()
-        # Unicode compatability test
         unicode_test_cases = {
             'cliché': 'clichés',
             'ångström': 'ångströms'

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import unittest
+import inflect
+
+
+class TestUnicode(unittest.TestCase):
+    def test_unicode(self):
+        engine = inflect.engine()
+        # Unicode compatability test
+        unicode_test_cases = {
+            'cliché': 'clichés'
+        }
+        for singular, plural in unicode_test_cases.items():
+            self.assertEqual(plural, engine.plural(singular))

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -12,7 +12,8 @@ class TestUnicode(unittest.TestCase):
         engine = inflect.engine()
         # Unicode compatability test
         unicode_test_cases = {
-            'cliché': 'clichés'
+            'cliché': 'clichés',
+            'ångström': 'ångströms'
         }
         for singular, plural in unicode_test_cases.items():
             self.assertEqual(plural, engine.plural(singular))


### PR DESCRIPTION
Unicode strings would cause errors in python 2.7 when using inflect. With this one additional line, no error is thrown.

Fixes #52 

Includes test file, testing for words containing unicode characters.