### PR TITLE
Capitalization

### DIFF
--- a/inflect.py
+++ b/inflect.py
@@ -1524,19 +1524,21 @@ class engine:
 # ## PLURAL SUBROUTINES
 
     def postprocess(self, orig, inflected):
-        """
-        FIX PEDANTRY AND CAPITALIZATION :-)
-        """
         if '|' in inflected:
             inflected = inflected.split('|')[self.classical_dict['all']]
-        if orig == "I":
-            return inflected
-        if orig == orig.upper():
-            return inflected.upper()
-        if orig[0] == orig[0].upper():
-            return '{}{}'.format(inflected[0].upper(),
-                                 inflected[1:])
-        return inflected
+        result = inflected.split(' ')
+        # Try to fix word wise capitalization
+        for index, word in enumerate(orig.split(' ')):
+            if word == 'I':
+                # Is this the only word for exceptions like this
+                # Where the original is fully capitalized without 'meaning' capitalization?
+                # Also this fails to handle a capitalizaion in context
+                continue
+            if word.capitalize() == word:
+                result[index] = result[index].capitalize()
+            if word == word.upper():
+                result[index] = result[index].upper()
+        return ' '.join(result)
 
     def partition_word(self, text):
         mo = search(r'\A(\s*)(.+?)(\s*)\Z', text)

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -214,7 +214,8 @@ class test(unittest.TestCase):
             ('COW', 'cows', 'COWS'),
             ('Cow', 'cows', 'Cows'),
             ('cow', 'cows|kine', 'cows'),
-            ('Entry', 'entries', 'Entries')
+            ('Entry', 'entries', 'Entries'),
+            ('can of Coke', 'cans of coke', 'cans of Coke')
         ):
             self.assertEqual(p.postprocess(orig, infl), txt)
 

--- a/tests/test_pwd.py
+++ b/tests/test_pwd.py
@@ -214,6 +214,7 @@ class test(unittest.TestCase):
             ('COW', 'cows', 'COWS'),
             ('Cow', 'cows', 'Cows'),
             ('cow', 'cows|kine', 'cows'),
+            ('Entry', 'entries', 'Entries')
         ):
             self.assertEqual(p.postprocess(orig, infl), txt)
 


### PR DESCRIPTION
Fix capitalization issues in processes where more than one word is involved.

Fixes #40 and includes tests against #5 and #40 