### PR TITLE
Upgrade 3.7-dev to 3.7 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: python
-
-python:
- - 3.7-dev
- - 3.6
- - 3.5
- - 3.4
- - pypy3
- - 2.7
- - pypy
-
 sudo: false # Use container-based infrastructure
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+    - python: 3.6
+    - python: 3.5
+    - python: 3.4
+    - python: pypy3
+    - python: 2.7
+    - python: pypy
 
 install:
  - pip install coverage tox-travis
@@ -22,6 +25,3 @@ after_success:
 
 after_script:
  - coverage report
-
-matrix:
-  fast_finish: true

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ pypy3 = pypy3
 3.4 = py34
 3.5 = py35
 3.6 = py36
-3.7-dev = py37, flake8
+3.7 = py37, flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
3.7-dev is an old alpha. Use 3.7 final instead.

Needs a little workaround for Travis CI: https://github.com/travis-ci/travis-ci/issues/9815.