### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: python
-sudo: false # Use container-based infrastructure
 
 matrix:
   fast_finish: true
   include:
   - python: 3.7
     dist: xenial
-    sudo: true
   - python: &latest_py3 3.6
   - python: 3.5
-  - python: 3.4
   - python: pypy3
   - python: 2.7
   - python: pypy

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setuptools.setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -31,7 +30,7 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Text Processing :: Linguistic",
     ],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=["importlib_metadata"],
     setup_requires=["setuptools_scm"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist = python
 pypy = pypy
 pypy3 = pypy3
 2.7 = py27
-3.4 = py34
 3.5 = py35
 3.6 = py36, black
 3.7 = py37, flake8


### PR DESCRIPTION
Python 3.4 is EOL and no longer receives security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.0 | 2008-12-03 | 2009-06-27
3.1 | 2009-06-27 | 2012-04-09
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history
