### PR TITLE
Fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ SYNOPSIS
 
  # GET BACK A LIST OF STRINGS, ONE FOR EACH "CHUNK"...
 
-    words = p.number_to_words(1234, getlist=True)    # ("one thousand","two hundred and thirty-four")
+    words = p.number_to_words(1234, wantlist=True)    # ("one thousand","two hundred and thirty-four")
 
 
  # OPTIONAL PARAMETERS CHANGE TRANSLATION:


### PR DESCRIPTION
Fixes #83.

The argument is `wantlist` not `getlist`:

```python
Python 3.7.4 (default, Jul  9 2019, 18:13:23)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(.startup.py)
(imported collections, datetime, itertools, math, os, pprint, re, sys, time)
>>> import inflect
>>> p = inflect.engine()
>>>
>>> p.number_to_words(1234, getlist=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: number_to_words() got an unexpected keyword argument 'getlist'
>>>
>>> p.number_to_words(1234, wantlist=True)
['one thousand', 'two hundred and thirty-four']
>>> p.number_to_words(1234)
'one thousand, two hundred and thirty-four'
>>>
```
