### PR TITLE
Test on latest PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: python
 python:
 - 2.7
 - 3.6
-- pypy3.5-6.0
-- pypy2.7-6.0
+- pypy3
+- pypy
 - &latest_py3 3.8
 
 jobs:


### PR DESCRIPTION
Currently:
```
Python 3.6.1 (784b254d6699, Apr 14 2019, 10:22:42)
[PyPy 7.1.1-beta0 with GCC 6.2.0 20160901]
```
and
```
Python 2.7.13 (8cdda8b8cdb8, Apr 14 2019, 14:06:44)
[PyPy 7.1.1 with GCC 6.2.0 20160901]
```
