### PR TITLE
Do not install the 'tests' package, fixes #88

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,3 +53,7 @@ docs =
 	# local
 
 [options.entry_points]
+
+[options.packages.find]
+exclude =
+  tests


### PR DESCRIPTION
Hi @jaraco,
I don't really know why I never noticed this before but v3.0.1 attempts to install the `tests` package.