### PR TITLE
Link badge to PyPI rather than static image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,7 @@
    :target: https://pypi.org/project/inflect
 
 .. image:: https://img.shields.io/pypi/pyversions/inflect.svg
+   :target: https://pypi.org/project/inflect
 
 .. image:: https://img.shields.io/travis/jazzband/inflect/master.svg
    :target: https://travis-ci.org/jazzband/inflect

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,10 @@
 .. image:: https://img.shields.io/pypi/v/inflect.svg
-   :target: https://pypi.org/project/inflect
+   :target: `PyPI link`_
 
 .. image:: https://img.shields.io/pypi/pyversions/inflect.svg
-   :target: https://pypi.org/project/inflect
+   :target: `PyPI link`_
+
+.. _PyPI link: https://pypi.org/project/inflect
 
 .. image:: https://img.shields.io/travis/jazzband/inflect/master.svg
    :target: https://travis-ci.org/jazzband/inflect


### PR DESCRIPTION
# Before

Links to https://camo.githubusercontent.com/b83044c95d5d1a2c1390bf6f3e9ec5acb0b4dcbd/68747470733a2f2f696d672e736869656c64732e696f2f707970692f707976657273696f6e732f696e666c6563742e737667

# After

Links to https://pypi.org/project/inflect/
