### PR TITLE
Remove references to nose

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ testing =
 	pytest-cov
 
 	# local
-	nose
 	pygments
 
 docs =

--- a/tests/test_pl_si.py
+++ b/tests/test_pl_si.py
@@ -1,5 +1,3 @@
-# use nosetest to run these tests
-
 import inflect
 
 FNAME = "tests/words.txt"


### PR DESCRIPTION
Also @hugovk why did you add pygments in c26f45f64885c81a73a64bb342753e6e2896a926? Is it to make pytest's output prettier? Shouldn't it be listed in `tox.ini` instead since it's not really required to run tests?