### PR TITLE
Add irregular plural case: chili -> chilis|chilies

### DIFF
--- a/inflect.py
+++ b/inflect.py
@@ -177,6 +177,7 @@ pl_sb_irregular_s = {
 
 pl_sb_irregular = {
     "child": "children",
+    "chili": "chilis|chilies",
     "brother": "brothers|brethren",
     "loaf": "loaves",
     "hoof": "hoofs|hooves",

--- a/tests/inflections.txt
+++ b/tests/inflections.txt
@@ -171,6 +171,7 @@
            chickenpox  ->  chickenpox
                 chief  ->  chiefs
                 child  ->  children
+                chili  ->  chilis|chilies
               Chinese  ->  Chinese
                chorus  ->  choruses
             chrysalis  ->  chrysalises|chrysalides
@@ -428,6 +429,7 @@
               Leonese  ->  Leonese
       lick of the cat  ->  licks of the cat
    Lieutenant General  ->  Lieutenant Generals
+                  lie  ->  lies
                  life  ->  lives
                 Liman  ->  Limans
                 lingo  ->  lingos
@@ -708,6 +710,7 @@
                suffix  ->  suffixes
             Sundanese  ->  Sundanese
              superior  ->  superiors
+               supply  ->  supplies
   TODO:singular_noun    Surgeon-General  ->  Surgeons-General
               surplus  ->  surpluses
             Swahilese  ->  Swahilese


### PR DESCRIPTION
Briefly considered devising a logical rule to determine plurality here, but it looks like this word is a bit of a special case; I added some contradictory test cases to the `inflections.txt` considered while trying to come up with a rule.

Plural forms defined as per wiktionary ([ref](https://en.wiktionary.org/wiki/chili)).